### PR TITLE
Handle Error in GetFolderResponseMessage

### DIFF
--- a/ewsclient/ewsgetfolderrequest.cpp
+++ b/ewsclient/ewsgetfolderrequest.cpp
@@ -118,7 +118,11 @@ EwsGetFolderRequest::Response::Response(QXmlStreamReader &reader)
         }
 
         if (reader.name() == QStringLiteral("Folders")) {
-            if (!parseFolders(reader)) {
+            if (responseClass() == EwsResponseError) {
+                // Skip empty folders element
+                reader.skipCurrentElement();
+            }
+            else if (!parseFolders(reader)) {
                 return;
             }
         }


### PR DESCRIPTION
In case a Folder which no longer exists is updated, the server responds
with a GetFolderResponseMessage with ResponseClass="Error".

The message contains an empty Folders element which has to be skipped,
otherwise the outer loop for the GetFolderResponseMessages will try to
traverse the Folders element on readNextStartElement.

Fixes #46 